### PR TITLE
fixing spurious compiler errors with gcc6+ on misuse of abs with unsi…

### DIFF
--- a/src/ProjectionLibrary/src/Filter.cpp
+++ b/src/ProjectionLibrary/src/Filter.cpp
@@ -20,42 +20,45 @@ extern "C" {
 
 #include "ShowArray.h"
 
+#include <cmath>
+
+
 using namespace MylibValues;
 using namespace VectorFunctions;
 using namespace ProjectionResults;
 
 
 namespace ProjectionMethod {
-  
+
   ////////////////////////////////////////////////////////////////////////////////
   /*
    Standard median filter
-   
+
    @param img:      input image
    @param imgPara:  struct with parameters
    @param original: current height map
    @param filterRadius:   Radius to define the 8-connected neighborhood
    */
-  
+
   Array * MedianFilter(RasterizedImage & img, ParaSet & imgPara, Array *original, int filterRadius){
-    
+
     // output image
     Array  *median = Make_Array_With_Shape(PLAIN_KIND,UINT32_TYPE,Coord2(original->dims[1], original->dims[0]));
     uint32 *med    = AUINT32(median);
     uint32 *orig    = AUINT32(original);
-    
+
 #ifdef DEVELOP
     Array  *variance = Make_Array_With_Shape(PLAIN_KIND,UINT32_TYPE,Coord2(original->dims[1], original->dims[0]));
     uint32 *var      = AUINT32(variance);
 #endif
-    
+
     Use_Reflective_Boundary();
-    
+
     // frames defines the local neighborhood
     Frame * f = Make_Frame(original,Coord2(2*filterRadius+1,2*filterRadius+1),Coord2(filterRadius,filterRadius));
     Histogram * h = Make_Histogram(UVAL,img.GetDepth(),ValU(1),ValU(0));
     Place_Frame(f,0);
-    
+
     for (Indx_Type p = 0; p < median->size; p++){
       Empty_Histogram(h);
       Histagain_Array(h,f,0);
@@ -66,54 +69,54 @@ namespace ProjectionMethod {
 #endif
       Move_Frame_Forward(f);
     }
-    
+
     Kill_Histogram(h);
     Kill_Frame(f);
-    
+
 #ifdef DEVELOP
     ShowArray(img, imgPara, "median.tif", median);
     ShowArray(img, imgPara, "variance.tif", variance);
     Free_Array(variance);
 #endif
-    
+
     if (imgPara.verbose){
       std::cout << "Planes filtered" << std::endl;
     }
-    
+
     return (median);
   }
-  
-  
-  
+
+
+
   ////////////////////////////////////////////////////////////////////////////////
   /*
    Median filter that only modifies a pixel when it significantly differs from the median of its 8-connected neighborhood given by the filterRadius
-   
+
    @param img:      input image
    @param imgPara:  struct with parameters
    @param original: current height map
    @param filterRadius:   radius to define the 8-connected neighborhood
    @param threshold: threshold to identify pixels that need to be modified
    */
-  
+
   Array * LocalMedianFilter(RasterizedImage & img, ParaSet & imgPara, Array * original, int filterRadius, double threshold ){
-    
+
     uint32 *orig    = AUINT32(original);
     Array  *median = Make_Array_With_Shape(PLAIN_KIND, UINT32_TYPE, Coord2(original->dims[1], original->dims[0]));
     uint32 *med    = AUINT32(median);
-    
+
     Use_Extend_Boundary();
-    
+
     Frame * f = Make_Frame(original,Coord2(2*filterRadius+1,2*filterRadius+1),Coord2(filterRadius, filterRadius));
     Histogram * h = Make_Histogram(UVAL,img.GetDepth(),ValU(1),ValU(0));
-    
-    
+
+
     Place_Frame(f,0);
     for (Indx_Type p = 0; p < median->size; p++){
       Empty_Histogram(h);
       Histagain_Array(h,f,0);
       h->counts[orig[p]]--;              // excludes the height of p in the calculation of the median
-      
+
       if (abs(static_cast<int>(orig[p]) - Percentile2Bin(h,.5)) > threshold) {      // replaces a pixel only if the different between the pixel value and the median is greater than the threshold
         med[p] = Percentile2Bin(h,.5);
       } else {
@@ -121,23 +124,23 @@ namespace ProjectionMethod {
       }
       Move_Frame_Forward(f);
     }
-    
+
     Kill_Histogram(h);
     Kill_Frame(f);
-    
+
     if (imgPara.verbose){
       std::cout << "Planes filtered" << std::endl;
     }
-    
+
     return median;
   }
-  
-  
-  
+
+
+
   ////////////////////////////////////////////////////////////////////////////////
   /*
    Median filter that only modifies a pixel when it significantly differs from the median of its 8-connected neighborhood that is weighted by the variance
-   
+
    @param img:        input image
    @param imgPara:    struct with parameters
    @param original:   current height map
@@ -145,102 +148,102 @@ namespace ProjectionMethod {
    @param threshold:  threshold to identify pixels that need to be modified
    */
   Array * LocalMedianFilter_InclVar(RasterizedImage & img, ParaSet & imgPara, Array * original, int filterRadius, double threshold){
-    
+
     uint32 *orig    = AUINT32(original);
     Array  *median = Make_Array_With_Shape(PLAIN_KIND, UINT32_TYPE, Coord2(original->dims[1], original->dims[0]));
     uint32 *med    = AUINT32(median);
-    
+
     Use_Extend_Boundary();
-    
+
     Frame * f = Make_Frame(original,Coord2(2*filterRadius+1,2*filterRadius+1),Coord2(filterRadius, filterRadius));
-    
+
     // Frame to compute the variance in intensity of the current grid element
     Frame * varF = Make_Frame(img.GetImage(),Coord3(1, imgPara.radius,imgPara.radius),Coord3(0, 0, 0));
     Histogram * varH = Make_Histogram(UVAL,256,ValU(1),ValU(0));
-    
+
     uint32 * data;
-    
+
     Place_Frame(f,0);
     Place_Frame(varF, 0);
-    
-    
+
+
     for (Dimn_Type y = 0; y <= img.GetHeight()-imgPara.radius; y += imgPara.radius){
       for (Dimn_Type x = 0; x <= img.GetWidth()-imgPara.radius; x += imgPara.radius){
-        
+
         Indx_Type pHM = (y/imgPara.radius) * original->dims[0] + (x/imgPara.radius);
         Place_Frame(f, pHM);
         data = (uint32 *) Frame_Values(f);
         std::vector<double> depths;
         double sum = 0;
         double n = 0;
-        
+
         for (int i = 0; i < AForm_Size(f); i++) {
           Indx_Type p = Coord2IdxA(img.GetImage(), Coord3(data[i],y, x));
           Place_Frame(varF, p);
           Histagain_Array(varH,varF,0);
-          
+
           sum += Histogram_Variance(varH) * data[i];
           n += Histogram_Variance(varH);
           for (int j=0; j< floor(Histogram_Variance(varH)/10); j++) {   // weight the current height with the variance
             depths.push_back(data[i]);
           }
         }
-        double weightedMedian = VectorMedian(depths);
-        
-        if (abs(orig[pHM] - weightedMedian) > threshold ) {
+        const double weightedMedian = VectorMedian(depths);
+
+        if (std::abs(double(orig[pHM]) - weightedMedian) > threshold ) {
           med[pHM] = floor(weightedMedian);
         } else {
           med[pHM] = orig[pHM];
         }
-        
+
       }
     }
-    
+
     Kill_Histogram(varH);
     Kill_Frame(varF);
     Kill_Frame(f);
-    
+
     return median;
   }
-  
-  
-  
+
+
+
   ////////////////////////////////////////////////////////////////////////////////
   /*
    Median filter that only modifies a pixel when it significantly differs from the median of its 8-connected neighborhood that is weighted by a likelihood
-   
+
    @param img:        input image
    @param imgPara:    struct with parameters
    @param original:   current height map
    @param filterRadius:     radius to define the 8-connected neighborhood
    @param threshold:  threshold to identify pixels that need to be modified
    @param confidence: image indicating for each image a 'likelihood' that this represents the correct surface
-   
+
    */
-  
+
   Array * LocalMedianFilter_Confidence(RasterizedImage & img, ParaSet & imgPara, Array * original, int filterRad, double threshold, Array * confidence){
-    
+
     uint32 *orig    = AUINT32(original);
     Array  *median = Make_Array_With_Shape(PLAIN_KIND, UINT32_TYPE, Coord2(original->dims[1], original->dims[0]));
     uint32 *med    = AUINT32(median);
-    
+
     Use_Extend_Boundary();
-    
+
     Frame * f = Make_Frame(original,Coord2(2*filterRad+1,2*filterRad+1),Coord2(filterRad, filterRad));
     Frame * confF = Make_Frame(confidence,Coord2(2*filterRad+1,2*filterRad+1),Coord2(filterRad, filterRad));
-    
+
     Place_Frame(f,0);
     Place_Frame(confF, 0);
-    
+
     uint8 * confVals;
     uint32 * data;
-    
+
     for (Indx_Type p = 0; p < median->size; p++){
       std::vector<double> heightVals;
-      
+
       data = (uint32 *) Frame_Values(f);
       confVals = (uint8 *) Frame_Values(confF);
-      
+
       for (int i = 0; i < AForm_Size(f); i++) {
         for (int j=0; j<confVals[i]; j++) {
           heightVals.push_back(data[i]);    // weight the height value with the 'likelihood' from the confidence image
@@ -251,58 +254,58 @@ namespace ProjectionMethod {
       } else {
         med[p] = VectorMedian(heightVals);
       }
-      
+
       Move_Frame_Forward(f);
       Move_Frame_Forward(confF);
     }
-    
+
     Kill_Frame(f);
     Kill_Frame(confF);
-    
+
     return median;
   }
-  
-  
+
+
   ////////////////////////////////////////////////////////////////////////////////
   /*
    Median filter that only modifies a pixel when it significantly differs from the median of its 8-connected neighborhood that is weighted by a likelihood
-   
+
    @param img:        input image
    @param imgPara:    struct with parameters
    @param original:   current height map
    @param filterRadius:     radius to define the 8-connected neighborhood
    @param threshold:  threshold to identify pixels that need to be modified
    @param confidence: image indicating for each image a 'likelihood' that this represents the correct surface
-   
+
    */
-  
+
   Array * LocalMedianFilter_3DConfidence(RasterizedImage & img, ParaSet & imgPara, Array * original, int filterRad, double threshold, Array * confidence){
-    
+
     uint32 *orig    = AUINT32(original);
     Array  *median = Make_Array_With_Shape(PLAIN_KIND, UINT32_TYPE, Coord2(original->dims[1], original->dims[0]));
     uint32 *med    = AUINT32(median);
     float32 * confVals = AFLOAT32(confidence);
     Use_Extend_Boundary();
-    
+
     Frame * f = Make_Frame(original,Coord2(2*filterRad+1,2*filterRad+1),Coord2(filterRad, filterRad));
 //    Frame * confF = Make_Frame(confidence,Coord3(1, 2*filterRad+1,2*filterRad+1),Coord3(0, filterRad, filterRad));
-    
+
     Place_Frame(f,0);
 //    Place_Frame(confF, 0);
-    
+
 //    uint8 * confVals;
     uint32 * data;
-    
+
     for (Indx_Type p = 0; p < median->size; p++){
       std::vector<double> heightVals;
-      
+
       data = (uint32 *) Frame_Values(f);
 //      confVals = (uint8 *) Frame_Values(confF);
-      
+
       for (int i = 0; i < AForm_Size(f); i++) {
-        
+
         Indx_Type q = data[i]* original->dims[1]*original->dims[0] + p;
-        
+
         for (int j=0; j< confVals[q]; j++) {
           heightVals.push_back(data[i]);    // weight the height value with the 'likelihood' from the confidence image
         }
@@ -312,34 +315,34 @@ namespace ProjectionMethod {
       } else {
         med[p] = VectorMedian(heightVals);
       }
-      
+
       Move_Frame_Forward(f);
 //      Move_Frame_Forward(confF);
     }
-    
+
     Kill_Frame(f);
 //    Kill_Frame(confF);
-    
+
     return median;
   }
-  
 
-  
+
+
   ////////////////////////////////////////////////////////////////////////////////
   /*
    Iterative filtering of the image using a median filter
-   
+
    @param img:          input image
    @param imgPara:      struct with parameters
    @param original:     current height map
    @param filterRadii:  array with the filter radii to define the 8-connected neighborhood
    @param threshold:    threshold to identify pixels that need to be modified
    */
-  
+
   /***********************
    * Iteration of the median filter using different radii
    **********************/
-  
+
   Array * Filtering (RasterizedImage & img, ParaSet & imgPara, Array * original, int filterRadii [], double threshold) {
     Array * median = Copy_Array(original);
 //    ComputeSmoothness(median);
@@ -348,28 +351,28 @@ namespace ProjectionMethod {
     for (int i=0; i < sizeof(filterRadii)/sizeof(*filterRadii); i++) {
       Free_Array(median);
       median = LocalMedianFilter(img, imgPara, original, filterRadii[i], threshold);
-      
+
 //      ComputeSmoothness(median);
       Free_Array(original);
       original = Copy_Array(median);
     }
-    
+
 #ifdef DEVELOP
     ShowArray(img, imgPara, "median.tif",median);
 #endif
     if (imgPara.verbose){
       std::cout << "Planes filtered" << std::endl;
     }
-    
+
     return median;
   }
-  
-  
-  
+
+
+
   ////////////////////////////////////////////////////////////////////////////////
   /*
    Iterative filtering of the image using a median filter, which integrates given likelihoods
-   
+
    @param img:          input image
    @param imgPara:      struct with parameters
    @param original:     current height map
@@ -377,10 +380,10 @@ namespace ProjectionMethod {
    @param threshold:    threshold to identify pixels that need to be modified
    @param confidence:   image indicating for each image a 'likelihood' that this represents the correct surface
    */
-  
+
   Array * Filtering_Confidence (RasterizedImage & img, ParaSet & imgPara, Array * original, int filterRadii [], double threshold, Array * confidence) {
     Array * median = Copy_Array(original);
-    
+
     // iterate through the list of radii and filter the image
     for (int i=0; i < sizeof(filterRadii)/sizeof(*filterRadii); i++) {
       Free_Array(median);
@@ -388,17 +391,17 @@ namespace ProjectionMethod {
       Free_Array(original);
       original = Copy_Array(median);
     }
-    
+
 #ifdef DEVELOP
     ShowArray(img, imgPara, "median.tif",median);
 #endif
     if (imgPara.verbose){
       std::cout << "Planes filtered" << std::endl;
     }
-    
+
     return median;
   }
-  
-  
-  
+
+
+
 }

--- a/src/ProjectionLibrary/src/ZPlaneSelection.cpp
+++ b/src/ProjectionLibrary/src/ZPlaneSelection.cpp
@@ -18,76 +18,77 @@ extern "C" {
 }
 
 #include "MylibValues.h"
+#include <cmath>
 
 using namespace MylibValues;
 
 namespace ProjectionMethod {
-  
+
   /***********************
    * Select the z-planes with the most occurrences of bright pixel
    **********************/
-  
+
   std::vector<Array *> PlaneSelection_SeveralLevels_8bit_ (RasterizedImage & img, ParaSet & imgPara, Array *maxim, Array *index){
-    
+
     int tmpGridX = ceil ((double)img.GetWidth()/(double)imgPara.radius);
     int tmpGridY  = ceil ((double)img.GetHeight()/(double)imgPara.radius);
-    
+
     std::vector<Array *> levels;
     std::vector<uint32 *> levs;
 
     uint8 * imgVals = AUINT8(img.GetImage());
-    
+
     for (int i=0; i<imgPara.layer; i++) {
       Array  *level = Make_Array_With_Shape(PLAIN_KIND,UINT32_TYPE,Coord2(tmpGridY,tmpGridX));
       uint32 *lev   = AUINT32(level);
-      
+
       levels.push_back(level);
       levs.push_back(lev);
     }
-    
+
     uint32 *idx   = AUINT32(index);
     uint8  *max   = AUINT8(maxim);
-    
+
 #ifdef DEVELOP
     Array *largest = Make_Array(PLAIN_KIND,UINT8_TYPE,2,maxim->dims);
     uint8 *big     = AUINT8(largest);
-    
+
     //Array_Op_Scalar(largest,SET_OP,IVAL,ValI(0));
-    
+
     Array *dist    = Make_Array_With_Shape(PLAIN_KIND, UINT32_TYPE, Coord3(img.GetGridX(), img.GetGridY(), img.GetDepth()));
     Array_Op_Scalar(dist, SET_OP, UINT32_TYPE, ValU(0));
     uint32 *dis    = AUINT32(dist);
 #endif
-    
+
     Use_Extend_Boundary();
-    
+
     Array  * brightPixelDistribution = Make_Array_With_Shape(PLAIN_KIND,UINT32_TYPE,Coord3(img.GetDepth(), tmpGridY,tmpGridX));
     Array_Op_Scalar(brightPixelDistribution, SET_OP, UINT32_TYPE, ValU(0));
     uint32 * brightVals = AUINT32(brightPixelDistribution);
-    
-    
+
+
     Frame * fimg = Make_Frame(img.GetImage(),Coord3(img.GetDepth(), imgPara.radius,imgPara.radius),Coord3(0,0,0));
-    
-    
+
+
     Histogram * wnh = Make_Histogram(UVAL,256,ValU(1),ValU(0));
-    
+
     Size_Type * hcnt = wnh->counts;
     Size_Type * dcnt = (Size_Type *) Guarded_Malloc(sizeof(Size_Type)*img.GetDepth(), Program_Name());
-    
+
     Indx_Type lp = 0;
-    
-    
+
+
     for (Dimn_Type y = 0; y <= img.GetHeight()-imgPara.radius; y += imgPara.radius){
       for (Dimn_Type x = 0; x <= img.GetWidth()-imgPara.radius; x += imgPara.radius){
         int thr;
-        
+
         Indx_Type p = y*img.GetWidth() + x;
-        
+
         Place_Frame(fimg,p);
 
         Empty_Histogram(wnh);
         Histagain_Array(wnh,fimg,0);
-        
+
         { int sum = 0;
           for (thr = 255; thr > 0; thr--)
           { sum += hcnt[thr];
@@ -95,33 +96,33 @@ namespace ProjectionMethod {
               break;
           }
         }
-        
+
         for (int d = 0; d < img.GetDepth(); d++){
           dcnt[d] = 0;
         }
-        
-        
+
+
         for (int z =0; z<img.GetDepth(); z++) {
           for (int r=0; r < imgPara.radius; r++) {
             for (int s=0; s<imgPara.radius; s++) {
               Indx_Type q = (z*img.GetHeight() + y+r ) * img.GetWidth() + (x+s);
-              
+
               if (imgVals[q] >= thr) {
                 dcnt[z] += 1;
               }
             }
           }
         }
-        
-        
+
+
         { std::vector<int> best;
           std::vector<int> plan;
-          
+
           if (dcnt[0] > dcnt[1]) {
             best.push_back(dcnt[0]);
             plan.push_back(0);
           }
-          
+
           for (int d = 1; d < img.GetDepth()-1; d++){
             if (dcnt[d] > dcnt[d-1] && dcnt[d] > dcnt[d+1]){
               best.push_back(dcnt[d]);
@@ -132,19 +133,19 @@ namespace ProjectionMethod {
             best.push_back(dcnt[img.GetDepth()-1]);
             plan.push_back(img.GetDepth()-1);
           }
-          
+
           // Assign values in level
           if (best.size() == imgPara.layer) {
             for (int i=0; i<imgPara.layer; i++) {
               lp = Coord2IdxA(levels[i], Coord2(y/imgPara.radius, x/imgPara.radius));
               levs[i][lp] = plan[i];
-              
+
             }
           } else if (best.size() == 0) {
             for (int i=0; i<imgPara.layer; i++) {
               lp = Coord2IdxA(levels[i], Coord2(y/imgPara.radius, x/imgPara.radius));
               levs[i][lp] = 0;
-              
+
             }
           } else if (best.size() < imgPara.layer) {
             for (int i=0; i<best.size(); i++) {
@@ -159,7 +160,7 @@ namespace ProjectionMethod {
             std::vector<int> sortBest (best.size());
             std::copy(best.begin(), best.end(), sortBest.begin());
             std::sort(sortBest.begin(), sortBest.end());
-            
+
             for (int i=0; i<best.size()-imgPara.layer; i++) {
               auto itr = std::find(best.begin(), best.end(), sortBest[i]);
               *itr = -1;
@@ -172,110 +173,110 @@ namespace ProjectionMethod {
                 j++;
               }
             }
-            
+
           }
-       
-          
+
+
 #ifdef DEVELOP
           Indx_Type pDist;
-          
+
           for (int j=0; j<img.GetDepth(); j++) {
             pDist = Coord2IdxA(dist, Coord3(x/imgPara.radius, y/imgPara.radius, j));
             dis[pDist] = (uint8)dcnt[j];
           }
 #endif
         }
-        
+
       }
     }
-    
+
     free(dcnt);
     Kill_Histogram(wnh);
     Kill_Frame(fimg);
-    
+
 #ifdef DEVELOP
     ShowArray(img, imgPara, "largest.tif",largest);
     Free_Array(largest);
-    
+
     Write_Image("dist.tif", dist, DONT_PRESS);
     Free_Array(dist);
 #endif
-    
+
     if (imgPara.verbose){
       std::cout << "Z-planes selected" << std::endl;
     }
-    
+
     for (int i=0; i<levels.size(); i++) {
       std::string path = "lev"+std::to_string(i)+".tif";
       Write_Image((char *)path.data(), levels[i], DONT_PRESS);
     }
-    
+
     return levels;
   }
-  
-  
+
+
   /***********************
    * Select the z-planes with the most occurrences of bright pixel
    **********************/
-  
+
   std::vector<Array *> PlaneSelection_SeveralLevels_8bit (RasterizedImage & img, ParaSet & imgPara, Array *maxim, Array *index){
-    
+
     int tmpGridX = ceil ((double)img.GetWidth()/(double)imgPara.radius);
     int tmpGridY  = ceil ((double)img.GetHeight()/(double)imgPara.radius);
-    
+
     std::vector<Array *> levels;
     std::vector<uint32 *> levs;
-    
-    
+
+
     for (int i=0; i<imgPara.layer; i++) {
       Array  *level = Make_Array_With_Shape(PLAIN_KIND,UINT32_TYPE,Coord2(tmpGridY,tmpGridX));
       uint32 *lev   = AUINT32(level);
-      
+
       levels.push_back(level);
       levs.push_back(lev);
     }
-    
+
     uint32 *idx   = AUINT32(index);
     uint8  *max   = AUINT8(maxim);
-    
+
 #ifdef DEVELOP
     Array *largest = Make_Array(PLAIN_KIND,UINT8_TYPE,2,maxim->dims);
     uint8 *big     = AUINT8(largest);
-    
+
     //Array_Op_Scalar(largest,SET_OP,IVAL,ValI(0));
-    
+
     Array *dist    = Make_Array_With_Shape(PLAIN_KIND, UINT32_TYPE, Coord3(img.GetGridX(), img.GetGridY(), img.GetDepth()));
     Array_Op_Scalar(dist, SET_OP, UINT32_TYPE, ValU(0));
     uint32 *dis    = AUINT32(dist);
 #endif
-    
+
     Use_Extend_Boundary();
-    
+
     Frame * fid = Make_Frame(index,Coord2(imgPara.radius,imgPara.radius),Coord2(0,0));
     Frame * fmx = Make_Frame(maxim,Coord2(imgPara.radius,imgPara.radius),Coord2(0,0));
     Offs_Type * off = Frame_Offsets(fid);
     Size_Type fsz   = AForm_Size(fid);
-    
+
     Histogram * wnh = Make_Histogram(UVAL,256,ValU(1),ValU(0));
-    
+
     Size_Type * hcnt = wnh->counts;
     Size_Type * dcnt = (Size_Type *) Guarded_Malloc(sizeof(Size_Type)*img.GetDepth(), Program_Name());
-    
+
     Indx_Type lp = 0;
-    
-    
+
+
     for (Dimn_Type y = 0; y <= img.GetHeight()-imgPara.radius; y += imgPara.radius){
       for (Dimn_Type x = 0; x <= img.GetWidth()-imgPara.radius; x += imgPara.radius){
         int thr;
-        
+
         Indx_Type p = y*img.GetWidth() + x;
-        
+
         Place_Frame(fmx,p);
         Place_Frame(fid,p);
-        
+
         Empty_Histogram(wnh);
         Histagain_Array(wnh,fmx,0);
-        
+
         { int sum = 0;
           for (thr = 255; thr > 0; thr--)
             { sum += hcnt[thr];
@@ -283,11 +284,11 @@ namespace ProjectionMethod {
                 break;
             }
         }
-        
+
         for (int d = 0; d < img.GetDepth(); d++){
           dcnt[d] = 0;
         }
-        
+
         if (Frame_Within_Array(fid)){
           uint8  *mx = max + p;
           uint32 *ix = idx + p;
@@ -305,15 +306,15 @@ namespace ProjectionMethod {
           std::cout << "Frame should never be outside array" << std::endl;
           exit (0);
         }
-        
+
         { std::vector<int> best;
           std::vector<int> plan;
-          
+
           if (dcnt[0] > dcnt[1]) {
             best.push_back(dcnt[0]);
             plan.push_back(0);
           }
-          
+
           for (int d = 1; d < img.GetDepth()-1; d++){
             if (dcnt[d] > dcnt[d-1] && dcnt[d] > dcnt[d+1]){
               best.push_back(dcnt[d]);
@@ -324,19 +325,19 @@ namespace ProjectionMethod {
             best.push_back(dcnt[img.GetDepth()-1]);
             plan.push_back(img.GetDepth()-1);
           }
-          
+
           // Assign values in level
           if (best.size() == imgPara.layer) {
             for (int i=0; i<imgPara.layer; i++) {
               lp = Coord2IdxA(levels[i], Coord2(y/imgPara.radius, x/imgPara.radius));
               levs[i][lp] = plan[i];
-              
+
             }
           } else if (best.size() == 0) {
             for (int i=0; i<imgPara.layer; i++) {
               lp = Coord2IdxA(levels[i], Coord2(y/imgPara.radius, x/imgPara.radius));
               levs[i][lp] = 0;
-              
+
             }
           } else if (best.size() < imgPara.layer) {
             for (int i=0; i<best.size(); i++) {
@@ -351,7 +352,7 @@ namespace ProjectionMethod {
             std::vector<int> sortBest (best.size());
             std::copy(best.begin(), best.end(), sortBest.begin());
             std::sort(sortBest.begin(), sortBest.end());
-            
+
             for (int i=0; i<best.size()-imgPara.layer; i++) {
               auto itr = std::find(best.begin(), best.end(), sortBest[i]);
               *itr = -1;
@@ -364,103 +365,103 @@ namespace ProjectionMethod {
                 j++;
               }
             }
-            
+
           }
-          
-          
+
+
 #ifdef DEVELOP
           Indx_Type pDist;
-          
+
           for (int j=0; j<img.GetDepth(); j++) {
             pDist = Coord2IdxA(dist, Coord3(x/imgPara.radius, y/imgPara.radius, j));
             dis[pDist] = (uint8)dcnt[j];
           }
 #endif
         }
-        
+
       }
     }
-    
+
     free(dcnt);
     Kill_Histogram(wnh);
     Kill_Frame(fid);
     Kill_Frame(fmx);
-    
+
 #ifdef DEVELOP
     ShowArray(img, imgPara, "largest.tif",largest);
     Free_Array(largest);
-    
+
     Write_Image("dist.tif", dist, DONT_PRESS);
     Free_Array(dist);
 #endif
-    
+
     if (imgPara.verbose){
       std::cout << "Z-planes selected" << std::endl;
     }
-    
+
 //    for (int i=0; i<levels.size(); i++) {
 //      std::string path = "lev"+std::to_string(i)+".tif";
 //      Write_Image((char *)path.data(), levels[i], DONT_PRESS);
 //    }
-    
+
     return levels;
   }
 
 
-  
+
   /***********************
    * Select the z-plane with the most occurrences of bright pixel
    **********************/
-  
+
   Array * PlaneSelection_8bit (RasterizedImage & img, ParaSet & imgPara, Array *maxim, Array *index){
 
     int tmpGridX = ceil ((double)img.GetWidth()/(double)imgPara.radius);
     int tmpGridY  = ceil ((double)img.GetHeight()/(double)imgPara.radius);
-    
+
     Array  *level = Make_Array_With_Shape(PLAIN_KIND,UINT32_TYPE,Coord2(tmpGridY,tmpGridX));
     uint32 *lev   = AUINT32(level);
-    
+
     uint32 *idx   = AUINT32(index);
     uint8  *max   = AUINT8(maxim);
-    
+
 #ifdef DEVELOP
     Array *largest = Make_Array(PLAIN_KIND,UINT8_TYPE,2,maxim->dims);
     uint8 *big     = AUINT8(largest);
-    
+
     //Array_Op_Scalar(largest,SET_OP,IVAL,ValI(0));
-    
+
     Array *dist    = Make_Array_With_Shape(PLAIN_KIND, UINT32_TYPE, Coord3(img.GetGridX(), img.GetGridY(), img.GetDepth()));
     Array_Op_Scalar(dist, SET_OP, UINT32_TYPE, ValU(0));
     uint32 *dis    = AUINT32(dist);
 #endif
-    
+
     Use_Extend_Boundary();
-    
+
     Frame * fid = Make_Frame(index,Coord2(imgPara.radius,imgPara.radius),Coord2(0,0));
     Frame * fmx = Make_Frame(maxim,Coord2(imgPara.radius,imgPara.radius),Coord2(0,0));
     Offs_Type * off = Frame_Offsets(fid);
     Size_Type fsz   = AForm_Size(fid);
-    
+
     Histogram * wnh = Make_Histogram(UVAL,256,ValU(1),ValU(0));
-    
+
     Size_Type * hcnt = wnh->counts;
     Size_Type * dcnt = (Size_Type *) Guarded_Malloc(sizeof(Size_Type)*img.GetDepth(), Program_Name());
-    
+
     Indx_Type lp = 0;
-    
-    
+
+
     for (Dimn_Type y = 0; y <= img.GetHeight()-imgPara.radius; y += imgPara.radius){
       for (Dimn_Type x = 0; x <= img.GetWidth()-imgPara.radius; x += imgPara.radius){
         int thr;
-        
+
         Indx_Type p = y*img.GetWidth() + x;
-        
+
         Place_Frame(fmx,p);
         Place_Frame(fid,p);
-        
+
         Empty_Histogram(wnh);
         Histagain_Array(wnh,fmx,0);
-        
+
         { int sum = 0;
           for (thr = 255; thr > 0; thr--)
           { sum += hcnt[thr];
@@ -468,138 +469,138 @@ namespace ProjectionMethod {
               break;
           }
         }
-        
+
         for (int d = 0; d < img.GetDepth(); d++){
           dcnt[d] = 0;
         }
-        
-        if (Frame_Within_Array(fid)){ 
+
+        if (Frame_Within_Array(fid)){
           uint8  *mx = max + p;
           uint32 *ix = idx + p;
 #ifdef DEVELOP
           uint8  *bg = big + p;
 #endif
           for (int d = 0; d < fsz; d++)
-            if (mx[off[d]] >= thr){ 
+            if (mx[off[d]] >= thr){
               dcnt[ix[off[d]]] += 1;
 #ifdef DEVELOP
               bg[off[d]] = mx[off[d]];
 #endif
             }
-        } else { 
+        } else {
           std::cout << "Frame should never be outside array" << std::endl;
           exit (0);
         }
-        
+
         { int best = 0;
           int plan;
-          
+
           for (int d = 0; d < img.GetDepth(); d++){
-            if (dcnt[d] > best){ 
+            if (dcnt[d] > best){
               best = dcnt[d];
               plan = d;
             }
           }
           lp = Coord2IdxA(level, Coord2(y/imgPara.radius, x/imgPara.radius));
           lev[lp] = plan;
-          
+
 #ifdef DEVELOP
           Indx_Type pDist;
-                    
+
           for (int j=0; j<img.GetDepth(); j++) {
             pDist = Coord2IdxA(dist, Coord3(x/imgPara.radius, y/imgPara.radius, j));
             dis[pDist] = (uint8)dcnt[j];
           }
 #endif
-        }      
-        
+        }
+
       }
     }
-    
+
     free(dcnt);
     Kill_Histogram(wnh);
     Kill_Frame(fid);
     Kill_Frame(fmx);
-    
+
 #ifdef DEVELOP
     ShowArray(img, imgPara, "largest.tif",largest);
     Free_Array(largest);
-    
+
     Write_Image("dist.tif", dist, DONT_PRESS);
     Free_Array(dist);
 #endif
-    
-    if (imgPara.verbose){ 
-      std::cout << "Z-planes selected" << std::endl; 
+
+    if (imgPara.verbose){
+      std::cout << "Z-planes selected" << std::endl;
     }
-    
+
     return level;
   }
-  
-  
+
+
   /***********************
    * Select the z-planes with the most occurrences of bright pixel
    * 16-bit images
    **********************/
-  
+
   std::vector<Array *> PlaneSelection_SeveralLevels_16bit (RasterizedImage & img, ParaSet & imgPara, Array *maxim, Array *index){
-    
+
     int tmpGridX = ceil ((double)img.GetWidth()/(double)imgPara.radius);
     int tmpGridY  = ceil ((double)img.GetHeight()/(double)imgPara.radius);
-    
+
     std::vector<Array *> levels;
     std::vector<uint32 *> levs;
-    
-    
+
+
     for (int i=0; i<imgPara.layer; i++) {
       Array  *level = Make_Array_With_Shape(PLAIN_KIND,UINT32_TYPE,Coord2(tmpGridY,tmpGridX));
       uint32 *lev   = AUINT32(level);
-      
+
       levels.push_back(level);
       levs.push_back(lev);
     }
-    
+
     uint32 *idx   = AUINT32(index);
     uint16  *max   = AUINT16(maxim);
-    
+
 #ifdef DEVELOP
     Array *largest = Make_Array(PLAIN_KIND,UINT8_TYPE,2,maxim->dims);
     uint16 *big     = AUINT16(largest);
-    
+
     //Array_Op_Scalar(largest,SET_OP,IVAL,ValI(0));
-    
+
     Array *dist    = Make_Array_With_Shape(PLAIN_KIND, UINT32_TYPE, Coord3(img.GetGridX(), img.GetGridY(), img.GetDepth()));
     Array_Op_Scalar(dist, SET_OP, UINT32_TYPE, ValU(0));
     uint32 *dis    = AUINT32(dist);
 #endif
-    
+
     Use_Extend_Boundary();
-    
+
     Frame * fid = Make_Frame(index,Coord2(imgPara.radius,imgPara.radius),Coord2(0,0));
     Frame * fmx = Make_Frame(maxim,Coord2(imgPara.radius,imgPara.radius),Coord2(0,0));
     Offs_Type * off = Frame_Offsets(fid);
     Size_Type fsz   = AForm_Size(fid);
-    
+
     Histogram * wnh = Make_Histogram(UVAL,65536,ValU(1),ValU(0));
-    
+
     Size_Type * hcnt = wnh->counts;
     Size_Type * dcnt = (Size_Type *) Guarded_Malloc(sizeof(Size_Type)*img.GetDepth(), Program_Name());
-    
+
     Indx_Type lp = 0;
-    
-    
+
+
     for (Dimn_Type y = 0; y <= img.GetHeight()-imgPara.radius; y += imgPara.radius){
       for (Dimn_Type x = 0; x <= img.GetWidth()-imgPara.radius; x += imgPara.radius){
         int thr;
-        
+
         Indx_Type p = y*img.GetWidth() + x;
-        
+
         Place_Frame(fmx,p);
         Place_Frame(fid,p);
-        
+
         Empty_Histogram(wnh);
         Histagain_Array(wnh,fmx,0);
-        
+
         { int sum = 0;
           for (thr = 65535; thr > 0; thr--)
           { sum += hcnt[thr];
@@ -607,11 +608,11 @@ namespace ProjectionMethod {
               break;
           }
         }
-        
+
         for (int d = 0; d < img.GetDepth(); d++){
           dcnt[d] = 0;
         }
-        
+
         if (Frame_Within_Array(fid)){
           uint16  *mx = max + p;
           uint32 *ix = idx + p;
@@ -629,15 +630,15 @@ namespace ProjectionMethod {
           std::cout << "Frame should never be outside array" << std::endl;
           exit (0);
         }
-        
+
         { std::vector<int> best;
           std::vector<int> plan;
-          
+
           if (dcnt[0] > dcnt[1]) {
             best.push_back(dcnt[0]);
             plan.push_back(0);
           }
-          
+
           for (int d = 1; d < img.GetDepth()-1; d++){
             if (dcnt[d] > dcnt[d-1] && dcnt[d] > dcnt[d+1]){
               best.push_back(dcnt[d]);
@@ -648,19 +649,19 @@ namespace ProjectionMethod {
             best.push_back(dcnt[img.GetDepth()-1]);
             plan.push_back(img.GetDepth()-1);
           }
-          
+
           // Assign values in level
           if (best.size() == imgPara.layer) {
             for (int i=0; i<imgPara.layer; i++) {
               lp = Coord2IdxA(levels[i], Coord2(y/imgPara.radius, x/imgPara.radius));
               levs[i][lp] = plan[i];
-              
+
             }
           } else if (best.size() == 0) {
             for (int i=0; i<imgPara.layer; i++) {
               lp = Coord2IdxA(levels[i], Coord2(y/imgPara.radius, x/imgPara.radius));
               levs[i][lp] = 0;
-              
+
             }
           } else if (best.size() < imgPara.layer) {
             for (int i=0; i<best.size(); i++) {
@@ -675,7 +676,7 @@ namespace ProjectionMethod {
             std::vector<int> sortBest (best.size());
             std::copy(best.begin(), best.end(), sortBest.begin());
             std::sort(sortBest.begin(), sortBest.end());
-            
+
             for (int i=0; i<best.size()-imgPara.layer; i++) {
               auto itr = std::find(best.begin(), best.end(), sortBest[i]);
               *itr = -1;
@@ -688,114 +689,114 @@ namespace ProjectionMethod {
                 j++;
               }
             }
-            
+
           }
-          
-          
+
+
 #ifdef DEVELOP
           Indx_Type pDist;
-          
+
           for (int j=0; j<img.GetDepth(); j++) {
             pDist = Coord2IdxA(dist, Coord3(x/imgPara.radius, y/imgPara.radius, j));
             dis[pDist] = (uint16)dcnt[j];
           }
 #endif
         }
-        
+
       }
     }
-    
+
     free(dcnt);
     Kill_Histogram(wnh);
     Kill_Frame(fid);
     Kill_Frame(fmx);
-    
+
 #ifdef DEVELOP
     ShowArray(img, imgPara, "largest.tif",largest);
     Free_Array(largest);
-    
+
     Write_Image("dist.tif", dist, DONT_PRESS);
     Free_Array(dist);
 #endif
-    
+
     if (imgPara.verbose){
       std::cout << "Z-planes selected" << std::endl;
     }
-    
+
     for (int i=0; i<levels.size(); i++) {
       std::string path = "lev"+std::to_string(i)+".tif";
       Write_Image((char *)path.data(), levels[i], DONT_PRESS);
     }
-    
+
     return levels;
   }
-  
+
 
   /***********************
    * Select the z-planes with the most occurrences of bright pixel
    * 16-bit images
    **********************/
-  
+
   Levels PlaneSelection_2Levels_16bit (RasterizedImage & img, ParaSet & imgPara, Array *maxim, Array *index){
-    
+
     int tmpGridX = ceil ((double)img.GetWidth()/(double)imgPara.radius);
     int tmpGridY  = ceil ((double)img.GetHeight()/(double)imgPara.radius);
-    
+
     Levels surfaces;
     std::vector<uint32 *> levs;
     surfaces.confidence = Make_Array_With_Shape(PLAIN_KIND,UINT8_TYPE,Coord2(tmpGridY,tmpGridX));
     uint8 * confVals = AUINT8(surfaces.confidence);
-    
-    
+
+
     for (int i=0; i<imgPara.layer; i++) {
       Array  *level = Make_Array_With_Shape(PLAIN_KIND,UINT32_TYPE,Coord2(tmpGridY,tmpGridX));
       uint32 *lev   = AUINT32(level);
-      
+
       surfaces.levels.push_back(level);
       levs.push_back(lev);
     }
-    
+
     uint32 *idx   = AUINT32(index);
     uint16  *max   = AUINT16(maxim);
-    
+
 #ifdef DEVELOP
     Array *largest = Make_Array(PLAIN_KIND,UINT8_TYPE,2,maxim->dims);
     uint16 *big     = AUINT16(largest);
-    
+
     //Array_Op_Scalar(largest,SET_OP,IVAL,ValI(0));
-    
+
     Array *dist    = Make_Array_With_Shape(PLAIN_KIND, UINT32_TYPE, Coord3(img.GetGridX(), img.GetGridY(), img.GetDepth()));
     Array_Op_Scalar(dist, SET_OP, UINT32_TYPE, ValU(0));
     uint32 *dis    = AUINT32(dist);
 #endif
-    
+
     Use_Extend_Boundary();
-    
+
     Frame * fid = Make_Frame(index,Coord2(imgPara.radius,imgPara.radius),Coord2(0,0));
     Frame * fmx = Make_Frame(maxim,Coord2(imgPara.radius,imgPara.radius),Coord2(0,0));
     Offs_Type * off = Frame_Offsets(fid);
     Size_Type fsz   = AForm_Size(fid);
-    
+
     Histogram * wnh = Make_Histogram(UVAL,65536,ValU(1),ValU(0));
-    
+
     Size_Type * hcnt = wnh->counts;
     Size_Type * dcnt = (Size_Type *) Guarded_Malloc(sizeof(Size_Type)*img.GetDepth(), Program_Name());
-    
+
     Indx_Type lp;
-    
-    
+
+
     for (Dimn_Type y = 0; y <= img.GetHeight()-imgPara.radius; y += imgPara.radius){
       for (Dimn_Type x = 0; x <= img.GetWidth()-imgPara.radius; x += imgPara.radius){
         int thr;
-        
+
         Indx_Type p = y*img.GetWidth() + x;
-        
+
         Place_Frame(fmx,p);
         Place_Frame(fid,p);
-        
+
         Empty_Histogram(wnh);
         Histagain_Array(wnh,fmx,0);
-        
+
         { int sum = 0;
           for (thr = 65535; thr > 0; thr--)
           { sum += hcnt[thr];
@@ -803,11 +804,11 @@ namespace ProjectionMethod {
               break;
           }
         }
-        
+
         for (int d = 0; d < img.GetDepth(); d++){
           dcnt[d] = 0;
         }
-        
+
         if (Frame_Within_Array(fid)){
           uint16  *mx = max + p;
           uint32 *ix = idx + p;
@@ -825,15 +826,15 @@ namespace ProjectionMethod {
           std::cout << "Frame should never be outside array" << std::endl;
           exit (0);
         }
-        
+
         { std::vector<int> best;
           std::vector<int> plan;
-          
+
           if (dcnt[0] > dcnt[1]) {
             best.push_back(dcnt[0]);
             plan.push_back(0);
           }
-          
+
           for (int d = 1; d < img.GetDepth()-1; d++){
             if (dcnt[d] > dcnt[d-1] && dcnt[d] > dcnt[d+1]){
               best.push_back(dcnt[d]);
@@ -844,31 +845,31 @@ namespace ProjectionMethod {
             best.push_back(dcnt[img.GetDepth()-1]);
             plan.push_back(img.GetDepth()-1);
           }
-          
+
           // Assign values in level
           //    Several cases:
           //        # peaks = 0   -> take level 0
           //        # peaks = 2   -> assign the according to the direction
           //        # peaks = 1   -> assign both to one
           //        # peaks > 2   -> determine 2 highest ones
-          
-          
-          
+
+
+
           if (best.size() == 2) {
             for (int i=0; i<2; i++) {
               lp = Coord2IdxA(surfaces.levels[i], Coord2(y/imgPara.radius, x/imgPara.radius));
               levs[i][lp] = plan[i];
-              
+
             }
             confVals[p] = 2;
           } else if (best.size() == 0) {
             for (int i=0; i<2; i++) {
               lp = Coord2IdxA(surfaces.levels[i], Coord2(y/imgPara.radius, x/imgPara.radius));
               levs[i][lp] = 0;
-              
+
             }
             confVals[p] = 0;
-            
+
           } else if (best.size() == 1) {
             for (int i=0; i<2; i++) {
               lp = Coord2IdxA(surfaces.levels[i], Coord2(y/imgPara.radius, x/imgPara.radius));
@@ -879,7 +880,7 @@ namespace ProjectionMethod {
             std::vector<int> sortBest (best.size());
             std::copy(best.begin(), best.end(), sortBest.begin());
             std::sort(sortBest.begin(), sortBest.end());
-            
+
             for (int i=0; i<best.size()-imgPara.layer; i++) {
               auto itr = std::find(best.begin(), best.end(), sortBest[i]);
               *itr = -1;
@@ -894,105 +895,105 @@ namespace ProjectionMethod {
             }
             confVals[p] = 1;
           }
-          
-          
+
+
 #ifdef DEVELOP
           Indx_Type pDist;
-          
+
           for (int j=0; j<img.GetDepth(); j++) {
             pDist = Coord2IdxA(dist, Coord3(x/imgPara.radius, y/imgPara.radius, j));
             dis[pDist] = (uint16)dcnt[j];
           }
 #endif
         }
-        
+
       }
     }
-    
+
     free(dcnt);
     Kill_Histogram(wnh);
     Kill_Frame(fid);
     Kill_Frame(fmx);
-    
+
 #ifdef DEVELOP
     ShowArray(img, imgPara, "largest.tif",largest);
     Free_Array(largest);
-    
+
     Write_Image("dist.tif", dist, DONT_PRESS);
     Free_Array(dist);
 #endif
-    
+
     if (imgPara.verbose){
       std::cout << "Z-planes selected" << std::endl;
     }
-    
+
     for (int i=0; i<surfaces.levels.size(); i++) {
       std::string path = "lev"+std::to_string(i)+".tif";
       Write_Image((char *)path.data(), surfaces.levels[i], DONT_PRESS);
     }
-    
+
     return surfaces;
   }
-  
-  
-  
 
-  
-  
+
+
+
+
+
   /***********************
    *
    * Select the z-plane with the most occurrences of bright pixel
    * 16-bit images
    **********************/
-  
+
   Array * PlaneSelection_16bit (RasterizedImage & img, ParaSet & imgPara, Array *maxim, Array *index){
-    
+
     int tmpGridX = ceil ((double)img.GetWidth()/(double)imgPara.radius);
     int tmpGridY  = ceil ((double)img.GetHeight()/(double)imgPara.radius);
-    
+
     Array  *level = Make_Array_With_Shape(PLAIN_KIND,UINT32_TYPE,Coord2(tmpGridY,tmpGridX));
     uint32 *lev   = AUINT32(level);
-    
+
     uint32 *idx   = AUINT32(index);
     uint16  *max   = AUINT16(maxim);
-    
+
 #ifdef DEVELOP
     Array *largest = Make_Array(PLAIN_KIND,UINT16_TYPE,2,maxim->dims);
     uint16 *big     = AUINT16(largest);
-    
+
     //Array_Op_Scalar(largest,SET_OP,IVAL,ValI(0));
-    
+
     Array *dist    = Make_Array_With_Shape(PLAIN_KIND, UINT32_TYPE, Coord3(img.GetGridX(), img.GetGridY(), img.GetDepth()));
     uint32 *dis    = AUINT32(dist);
 #endif
-    
+
     Use_Extend_Boundary();
-    
+
     Frame * fid = Make_Frame(index,Coord2(imgPara.radius,imgPara.radius),Coord2(0,0));
     Frame * fmx = Make_Frame(maxim,Coord2(imgPara.radius,imgPara.radius),Coord2(0,0));
     Offs_Type * off = Frame_Offsets(fid);
     Size_Type fsz   = AForm_Size(fid);
-    
+
     Histogram * wnh = Make_Histogram(UVAL,65536,ValU(1),ValU(0));
-    
+
     Size_Type * hcnt = wnh->counts;
     Size_Type * dcnt = (Size_Type *) Guarded_Malloc(sizeof(Size_Type)*img.GetDepth(), Program_Name());
-    
+
     Indx_Type lp = 0;
-    
-    
+
+
     for (Dimn_Type y = 0; y <= img.GetHeight()-imgPara.radius; y += imgPara.radius){
       for (Dimn_Type x = 0; x <= img.GetWidth()-imgPara.radius; x += imgPara.radius){
         int thr;
-        
+
         Indx_Type p = y*img.GetWidth() + x;
-        
+
         Place_Frame(fmx,p);
         Place_Frame(fid,p);
-        
+
         Empty_Histogram(wnh);
         Histagain_Array(wnh,fmx,0);
-        
+
         { int sum = 0;
           for (thr = 65535; thr > 0; thr--)
           { sum += hcnt[thr];
@@ -1000,11 +1001,11 @@ namespace ProjectionMethod {
               break;
           }
         }
-        
+
         for (int d = 0; d < img.GetDepth(); d++){
           dcnt[d] = 0;
         }
-        
+
         if (Frame_Within_Array(fid)){
           uint16  *mx = max + p;
           uint32 *ix = idx + p;
@@ -1022,10 +1023,10 @@ namespace ProjectionMethod {
           std::cout << "Frame should never be outside array" << std::endl;
           exit (0);
         }
-        
+
         { int best = 0;
           int plan;
-          
+
           for (int d = 0; d < img.GetDepth(); d++){
             if (dcnt[d] > best){
               best = dcnt[d];
@@ -1034,37 +1035,37 @@ namespace ProjectionMethod {
           }
           lp = Coord2IdxA(level, Coord2(y/imgPara.radius, x/imgPara.radius));
           lev[lp] = plan;
-          
+
 #ifdef DEVELOP
           Indx_Type pDist;
-          
+
           for (int j=0; j<img.GetDepth(); j++) {
             pDist = Coord2IdxA(dist, Coord3(x/imgPara.radius, y/imgPara.radius, j));
             dis[pDist] = (uint8)dcnt[j];
           }
 #endif
         }
-        
+
       }
     }
-    
+
     free(dcnt);
     Kill_Histogram(wnh);
     Kill_Frame(fid);
     Kill_Frame(fmx);
-    
+
 #ifdef DEVELOP
     ShowArray(img, imgPara, "largest.tif",largest);
     Free_Array(largest);
-    
+
     Write_Image("dist.tif", dist, DONT_PRESS);
     Free_Array(dist);
 #endif
-    
+
     if (imgPara.verbose){
       std::cout << "Z-planes selected" << std::endl;
     }
-    
+
     return level;
   }
 
@@ -1072,55 +1073,55 @@ namespace ProjectionMethod {
    * Select the z-plane with the most occurrences of bright pixel
    *    Uses a window size twice the size of the input radius
    **********************/
-  
-  
+
+
   Array * PlaneSelection_DoubleRadius (RasterizedImage & img, ParaSet & imgPara, Array *maxim, Array *index, int rad){
-        
+
     int tmpGridX = ceil ((double)img.GetWidth()/(double)(rad/2));
     int tmpGridY  = ceil ((double)img.GetHeight()/(double)(rad/2));
-    
+
     Array  *level = Make_Array_With_Shape(PLAIN_KIND,UINT32_TYPE,Coord2(tmpGridY,tmpGridX));
     uint32 *lev   = AUINT32(level);
-    
+
     uint32 *idx   = AUINT32(index);
     uint8  *max   = AUINT8(maxim);
-    
+
 #ifdef DEVELOP
     Array *largest = Make_Array(PLAIN_KIND,UINT8_TYPE,2,maxim->dims);
     uint8 *big     = AUINT8(largest);
-    
+
     //Array_Op_Scalar(largest,SET_OP,IVAL,ValI(0));
-    
+
     Array *dist    = Make_Array_With_Shape(PLAIN_KIND, UINT32_TYPE, Coord3(ceil ((double)img.GetHeight()/(double)(rad)), ceil ((double)img.GetWidth()/(double)(rad)), img.GetDepth()));
     uint32 *dis    = AUINT32(dist);
 #endif
-    
+
     Use_Extend_Boundary();
-    
+
     Frame * fid = Make_Frame(index,Coord2(rad,rad),Coord2(0,0));
     Frame * fmx = Make_Frame(maxim,Coord2(rad,rad),Coord2(0,0));
     Offs_Type * off = Frame_Offsets(fid);
     Size_Type fsz = AForm_Size(fid);
-    
+
     Histogram * wnh = Make_Histogram(UVAL,256,ValU(1),ValU(0));
-    
+
     Size_Type * hcnt = wnh->counts;
     Size_Type * dcnt = (Size_Type *) Guarded_Malloc(sizeof(Size_Type)*img.GetDepth(),Program_Name());
-    
-    
+
+
     Indx_Type lp = 0;
     for (Dimn_Type y = 0; y <= img.GetHeight()-rad; y += rad){
       for (Dimn_Type x = 0; x <= img.GetWidth()-rad; x += rad){
         int thr;
-        
+
         Indx_Type p = y*img.GetWidth() + x;
-        
+
         Place_Frame(fmx,p);
         Place_Frame(fid,p);
-        
+
         Empty_Histogram(wnh);
         Histagain_Array(wnh,fmx,0);
-        
+
         { int sum = 0;
           for (thr = 255; thr > 0; thr--){
             sum += hcnt[thr];
@@ -1129,11 +1130,11 @@ namespace ProjectionMethod {
             }
           }
         }
-        
+
         for (int d = 0; d < img.GetDepth(); d++){
           dcnt[d] = 0;
         }
-        
+
         if (Frame_Within_Array(fid)){
           uint8  *mx = max + p;
           uint32 *ix = idx + p;
@@ -1151,10 +1152,10 @@ namespace ProjectionMethod {
           std::cout << "Frame should never be outside array" << std::endl;
           exit (0);
         }
-        
+
         { int plan;
           int best = 0;
-          
+
           for (int d = 0; d < img.GetDepth(); d++){
             if (dcnt[d] > best){
               best = dcnt[d];
@@ -1163,102 +1164,102 @@ namespace ProjectionMethod {
           }
           lp = Coord2IdxA(level, Coord2((2*y)/rad, (2*x)/rad));
           lev[lp] = plan;
-          
+
           lp = Coord2IdxA(level, Coord2((2*y+rad)/rad, (2*x)/rad));
           lev[lp] = plan;
-          
+
           lp = Coord2IdxA(level, Coord2((2*y)/rad, (2*x+rad)/rad));
           lev[lp] = plan;
-          
+
           lp = Coord2IdxA(level, Coord2((2*y+rad)/rad, (2*x+rad)/rad));
           lev[lp] = plan;
-          
-          
+
+
 #ifdef DEVELOP
           Indx_Type pDist;
-          
+
           for (int j=0; j<img.GetDepth(); j++) {
             pDist = Coord2IdxA(dist, Coord3(y/rad, x/rad, j));
             dis[pDist] = (uint8)dcnt[j];
           }
 #endif
-        }      
-        
+        }
+
       }
     }
-    
+
     free(dcnt);
     Kill_Histogram(wnh);
     Kill_Frame(fid);
     Kill_Frame(fmx);
-    
+
 #ifdef DEVELOP
     ShowArray(img, imgPara, "largest.tif",largest);
     Free_Array(largest);
-    
-    Write_Image("dist.tif", dist, DONT_PRESS);  
+
+    Write_Image("dist.tif", dist, DONT_PRESS);
     Free_Array(dist);
-    
+
     ShowArray(img, imgPara, "level_inital.tif", level);
 #endif
-    
-    if (imgPara.verbose){ 
-      std::cout << "Z-planes selected" << std::endl; 
+
+    if (imgPara.verbose){
+      std::cout << "Z-planes selected" << std::endl;
     }
-    
+
     return level;
   }
-  
+
   /***********************
    *
    * Select the z-plane with the highest entropy
    *    Uses a subset of the stack defined by a reference height map and a distance
    * 8-bit images
    **********************/
-  
-  
+
+
   Array * SelectPlanes_Variance_8bit(RasterizedImage & img, ParaSet & imgPara, Array * median){
-        
+
     Array  *level = Make_Array_With_Shape(PLAIN_KIND,UINT32_TYPE,Coord2(img.GetGridY(),img.GetGridX()));
     uint32 *lev   = AUINT32(level);
     uint32 * med  = AUINT32(median);
-    
+
     Use_Reflective_Boundary();
-    
+
     Frame * f = Make_Frame(img.GetImage(),Coord3(1,imgPara.radius,imgPara.radius),Coord3(0, 0, 0));
     Histogram * h = Make_Histogram(UVAL,256,ValU(1),ValU(0));
-    
+
     Place_Frame(f, 0);
-    
+
     double maxVar;
     double maxmaxVar;
     int best, maxBest;
     Indx_Type p;
-    
+
     for (Dimn_Type y = 0; y <= img.GetHeight()-imgPara.radius; y += imgPara.radius){
       for (Dimn_Type x = 0; x <= img.GetWidth()-imgPara.radius; x += imgPara.radius){
         best = 0;
         maxVar = 1.5;
         maxmaxVar = 0;
         maxBest = 0;
-        
+
         //        std::cout << x << ", " << y << "   ( " << x/imgPara.radius << ", " << y/ imgPara.radius << std::endl;
         Indx_Type medIdx = (y/imgPara.radius) * img.GetGridX()+ (x/imgPara.radius);
-        
+
         for (Dimn_Type z=med[medIdx]-imgPara.distance ; z<=med[medIdx]+imgPara.distance ; z++) {
           if ((z < 0) or (z >= img.GetDepth())) {
             continue;
           }
-          
+
           p = Coord2IdxA(img.GetImage(), Coord3(z, y, x));
           Place_Frame(f, p);
-          
+
           Empty_Histogram(h);
           Histagain_Array(h,f,0);
           //          if (Histogram_Variance(h) > 0) {
           //             std::cout << "     " << z << " => " << Histogram_Variance(h) << std::endl;
           //          }
-          
+
           if (maxVar < Histogram_Variance(h)) {
             maxVar = Histogram_Variance(h);
             best = z;
@@ -1268,18 +1269,18 @@ namespace ProjectionMethod {
             maxBest = z;
           }
         }
-        
+
         double betweenVar = maxVar;
         int betweenBest = 0;
-        
+
         if (best == med[medIdx]-imgPara.distance) {
-          
+
           int z = best -1;
           while (z >= 0) {
-            
+
             p = Coord2IdxA(img.GetImage(), Coord3(z, y, x));
             Place_Frame(f, p);
-            
+
             Empty_Histogram(h);
             Histagain_Array(h,f,0);
             //            if (Histogram_Variance(h) > 1) {
@@ -1289,7 +1290,7 @@ namespace ProjectionMethod {
               maxmaxVar = Histogram_Variance(h);
               maxBest = z;
             }
-            
+
             if (betweenVar < Histogram_Variance(h)) {
               betweenVar = Histogram_Variance(h);
               betweenBest = z;
@@ -1298,15 +1299,15 @@ namespace ProjectionMethod {
               z = -1;
             }
           }
-          
+
         } else if (best == 0) {
-          
+
           int z = med[medIdx]-imgPara.distance -1;
           while (z >= 0) {
-            
+
             p = Coord2IdxA(img.GetImage(), Coord3(z, y, x));
             Place_Frame(f, p);
-            
+
             Empty_Histogram(h);
             Histagain_Array(h,f,0);
             //            if (Histogram_Variance(h) > 0) {
@@ -1316,7 +1317,7 @@ namespace ProjectionMethod {
               maxmaxVar = Histogram_Variance(h);
               maxBest = z;
             }
-            
+
             if (betweenVar < Histogram_Variance(h)) {
               betweenVar = Histogram_Variance(h);
               betweenBest = z;
@@ -1327,18 +1328,18 @@ namespace ProjectionMethod {
               z = -1;
             }
           }
-          
+
         }
-        
-        
+
+
         if (best == med[medIdx]+imgPara.distance) {
-          
+
           int z = best + 1;
           while (z < img.GetDepth()) {
-            
+
             p = Coord2IdxA(img.GetImage(), Coord3(z, y, x));
             Place_Frame(f, p);
-            
+
             Empty_Histogram(h);
             Histagain_Array(h,f,0);
             //            if (Histogram_Variance(h) > 0) {
@@ -1348,7 +1349,7 @@ namespace ProjectionMethod {
               //              maxmaxVar = Histogram_Variance(h);
               maxBest = z;
             }
-            
+
             if (maxVar < Histogram_Variance(h)) {
               maxVar = Histogram_Variance(h);
               best = z;
@@ -1357,15 +1358,15 @@ namespace ProjectionMethod {
               z = img.GetDepth();
             }
           }
-          
+
         } else if (best == 0) {
-          
+
           int z = med[medIdx]+imgPara.distance + 1;
           while (z < img.GetDepth()) {
-            
+
             p = Coord2IdxA(img.GetImage(), Coord3(z, y, x));
             Place_Frame(f, p);
-            
+
             Empty_Histogram(h);
             Histagain_Array(h,f,0);
             //            if (Histogram_Variance(h) > 1) {
@@ -1375,7 +1376,7 @@ namespace ProjectionMethod {
               maxmaxVar = Histogram_Variance(h);
               maxBest = z;
             }
-            
+
             if (maxVar < Histogram_Variance(h)) {
               maxVar = Histogram_Variance(h);
               best = z;
@@ -1386,13 +1387,15 @@ namespace ProjectionMethod {
               z = img.GetDepth();
             }
           }
-          
+
         }
-        
-        if (abs(betweenBest - med[medIdx]-imgPara.distance) < abs(best-med[medIdx]+imgPara.distance)) {
+
+        auto lhs = std::abs(betweenBest - int(med[medIdx])-int(imgPara.distance));
+        auto rhs = std::abs(best-int(med[medIdx])+int(imgPara.distance));
+        if (lhs < rhs) {
           best = betweenBest;
         }
-        
+
         if (best == 0) {
           best = maxBest;
         }
@@ -1401,8 +1404,8 @@ namespace ProjectionMethod {
         lev[p] = best;
       }
     }
-    
-    
+
+
 #ifdef DEVELOP
     ShowArray(img, imgPara, "level_Variance.tif", level);
 #endif
@@ -1411,178 +1414,178 @@ namespace ProjectionMethod {
     }
     Free_Frame(f);
     Free_Histogram(h);
-    
+
     return level;
   }
 
-  
+
   /***********************
    *
    * Select the z-plane with the highest entropy
    *    Uses a subset of the stack defined by a reference height map and a distance
    * 16-bit images
    **********************/
-  
-  
+
+
   Array * SelectPlanes_Variance_16bit(RasterizedImage & img, ParaSet & imgPara, Array * substack){
-    
+
     Array  *level = Make_Array_With_Shape(PLAIN_KIND,UINT32_TYPE,Coord2(img.GetGridY(),img.GetGridX()));
     uint32 *lev   = AUINT32(level);
-    
+
     Use_Reflective_Boundary();
-    
+
     Frame * f = Make_Frame(substack,Coord3(1,imgPara.radius,imgPara.radius),Coord3(0, 0, 0));
-    
+
     /*****
      * Fast version
      *****/
     Histogram * h = Make_Histogram(UVAL,256,ValU(1),ValU(0));
-    
+
     /*****
      * More accurate but slow version
      *****/
     //Histogram * h = Make_Histogram(UVAL,2048,ValU(32),ValU(0));
-    
+
 
     Place_Frame(f, 0);
-    
+
     double maxVar;
     int best;
     Indx_Type p;
-    
+
     for (Dimn_Type y = 0; y <= img.GetHeight()-imgPara.radius; y += imgPara.radius){
       for (Dimn_Type x = 0; x <= img.GetWidth()-imgPara.radius; x += imgPara.radius){
         best = 0;
         maxVar = 0;
-        
+
         for (Dimn_Type z=0; z<img.GetDepth(); z++) {
           p = Coord2IdxA(substack, Coord3(z, y, x));
           Place_Frame(f, p);
-          
+
           Empty_Histogram(h);
           Histagain_Array(h,f,0);
-          
+
           if (maxVar < Histogram_Variance(h)) {
             maxVar = Histogram_Variance(h);
             best = z;
           }
-          
+
         }
         p = Coord2IdxA(level, Coord2(y/imgPara.radius, x/imgPara.radius));
         lev[p] = best;
-        
+
       }
     }
-    
-    
+
+
 #ifdef DEVELOP
     ShowArray(img, imgPara, "level_Variance.tif", level);
 #endif
     if (imgPara.verbose){
       std::cout << "Optimal planes selected (showing highest variance)" << std::endl;
     }
-    
+
     Free_Frame(f);
     Free_Histogram(h);
     return level;
   }
 
-  
+
   /***********************
    * Select the z-plane with the highest entropy
    *    Uses a subset of the stack defined by a reference height map and a distance
    **********************/
 
-  
+
   Array * SelectPlanes_Entropy(RasterizedImage & img, ParaSet & imgPara, Array * substack){
-    
+
     Array  *level = Make_Array_With_Shape(PLAIN_KIND,UINT32_TYPE,Coord2(img.GetGridY(),img.GetGridX()));
     uint32 *lev   = AUINT32(level);
-    
+
     Use_Reflective_Boundary();
-    
-    Frame * f = Make_Frame(substack,Coord3(1,imgPara.radius,imgPara.radius),Coord3(0, 0, 0));  
+
+    Frame * f = Make_Frame(substack,Coord3(1,imgPara.radius,imgPara.radius),Coord3(0, 0, 0));
     Histogram * h = Make_Histogram(UVAL,256,ValU(1),ValU(0));
-    
-    Place_Frame(f, 0);  
-    
+
+    Place_Frame(f, 0);
+
     double maxVar;
     int best;
     Indx_Type p;
-    
+
     for (Dimn_Type y = 0; y <= img.GetHeight()-imgPara.radius; y += imgPara.radius){
       for (Dimn_Type x = 0; x <= img.GetWidth()-imgPara.radius; x += imgPara.radius){
         best = 0;
         maxVar = 0;
-        
+
         for (Dimn_Type z=0; z<img.GetDepth(); z++) {
           p = Coord2IdxA(substack, Coord3(z, y, x));
           Place_Frame(f, p);
-          
+
           Empty_Histogram(h);
           Histagain_Array(h,f,0);
-          
+
           if (maxVar < Histogram_Entropy(h)) {
             maxVar = Histogram_Entropy(h);
             best = z;
           }
-          
+
         }
         p = Coord2IdxA(level, Coord2(y/imgPara.radius, x/imgPara.radius));
         lev[p] = best;
-        
+
       }
     }
-    
-    
-#ifdef DEVELOP  
+
+
+#ifdef DEVELOP
     ShowArray(img, imgPara, "level_Entropy.tif", level);
 #endif
     if (imgPara.verbose){
       std::cout << "Optimal planes selected (showing highest entropy)" << std::endl;
     }
-    
+
     Free_Frame(f);
     Free_Histogram(h);
     return level;
   }
 
-  
+
   /***********************
    * Select the z-plane with the highest LOG score
    **********************/
-  
-  
+
+
   Array * SelectPlanes_LOG(RasterizedImage & img, ParaSet & imgPara, Array * substack){
 
     Convert_Array_Inplace(substack, PLAIN_KIND, INT32_TYPE, 32, 0);
-    
+
     Array * logImage = LOG_Array(substack, 1.0, 3);
-        
+
     Convert_Array_Inplace(logImage, PLAIN_KIND, UINT32_TYPE, 32, 0);
 
     uint32 * logVal = AUINT32(logImage);
-    
-        
+
+
     // Going through the image, pixel by pixel and determine the maximal absolut value for each z-column
-        
+
     Array * indexLoG = Make_Array_With_Shape(PLAIN_KIND, UINT32_TYPE, Coord2(img.GetHeight(), img.GetWidth()));
     uint32 * idxLoG = AUINT32(indexLoG);
-    
+
     Array * maximLoG = Make_Array_With_Shape(PLAIN_KIND, UINT32_TYPE, Coord2(img.GetHeight(), img.GetWidth()));
     uint32 * maxLoG = AUINT32(maximLoG);
-    
+
     uint32 maxValue, maxIndex;
     Indx_Type q;
-    
-    for (Indx_Type p = 0; p < img.GetArea(); p++){ 
-      maxValue = abs(logVal[p]);
+
+    for (Indx_Type p = 0; p < img.GetArea(); p++){
+      maxValue = logVal[p];
       maxIndex = 0;
       q = p + img.GetArea();
-      
-      for (Dimn_Type d = 1; d < img.GetDepth(); d++){ 
-        if (abs(logVal[q]) >= maxValue) {
-          maxValue = abs(logVal[q]);
+
+      for (Dimn_Type d = 1; d < img.GetDepth(); d++){
+        if (logVal[q] >= maxValue) {
+          maxValue = logVal[q];
           maxIndex = d;
         }
         q += img.GetArea();
@@ -1590,137 +1593,137 @@ namespace ProjectionMethod {
       maxLoG[p] = maxValue;
       idxLoG[p] = maxIndex;
     }
-   
+
     RasterizedImage imgLoG = RasterizedImage(logImage);
     imgLoG.SetGrid(imgPara.radius);
-    
+
     Array * level = PlaneSelection_8bit(imgLoG, imgPara, maximLoG, indexLoG);
-        
-        
+
+
 #ifdef DEVELOP
      Write_Image("logImage.tif", logImage, DONT_PRESS);
-    
+
     ShowArray(imgLoG, imgPara, "maxim_loG.tif", maximLoG);
     ShowArray(imgLoG, imgPara, "index_loG.tif", indexLoG);
     ShowArray(img, imgPara, "level_LoG.tif", level);
 #endif
-    
+
     if (imgPara.verbose) {
       std::cout << "Optimal planes selected (using LoG)" << std::endl;
     }
-    
+
     Free_Array(maximLoG);
     Free_Array(indexLoG);
     Free_Array(logImage);
-    
+
     return level;
   }
-  
-  
+
+
   /***********************
    * Select the z-plane with the highest LOG score -> basal cell layer
    **********************/
-  
-  
+
+
   Array * SelectPlanes_LOG_basal(RasterizedImage & img, ParaSet & imgPara, Array * substack){
-    
+
     Convert_Array_Inplace(substack, PLAIN_KIND, INT32_TYPE, 32, 0);
-    
+
     Array * logImage = LOG_Array(substack, 1.0, 3);
-    
+
     Convert_Array_Inplace(logImage, PLAIN_KIND, UINT32_TYPE, 32, 0);
-    
+
     uint32 * logVal = AUINT32(logImage);
-    
+
     Write_Image("logImage.tif", logImage, DONT_PRESS);
-    
-    
+
+
     // Going through the image, pixel by pixel and determine the maximal absolut value for each z-column
-    
+
     Array * indexLoG = Make_Array_With_Shape(PLAIN_KIND, UINT32_TYPE, Coord2(img.GetHeight(), img.GetWidth()));
     uint32 * idxLoG = AUINT32(indexLoG);
-    
+
     Array * maximLoG = Make_Array_With_Shape(PLAIN_KIND, UINT32_TYPE, Coord2(img.GetHeight(), img.GetWidth()));
     uint32 * maxLoG = AUINT32(maximLoG);
-    
+
     uint32 maxValue, maxIndex;
     Indx_Type q;
-    
-    for (Indx_Type p = 0; p < img.GetArea(); p++){ 
-      maxValue = abs(logVal[p]);
+
+    for (Indx_Type p = 0; p < img.GetArea(); p++){
+      maxValue = logVal[p];
       maxIndex = 0;
       q = p + img.GetArea();
-      
-      for (Dimn_Type d = 1; d < img.GetDepth(); d++){ 
-        if (abs(logVal[q]) >= maxValue) {
-          maxValue = abs(logVal[q]);
+
+      for (Dimn_Type d = 1; d < img.GetDepth(); d++){
+        if (logVal[q] >= maxValue) {
+          maxValue = logVal[q];
           maxIndex = d;
         }
-        
+
         q += img.GetArea();
       }
       maxLoG[p] = maxValue;
       idxLoG[p] = maxIndex;
     }
     RasterizedImage imgLoG = RasterizedImage(logImage);
-    
-    
+
+
 #ifdef DEVELOP
     ShowArray(imgLoG, imgPara, "maxim_loG.tif", maximLoG);
     ShowArray(imgLoG, imgPara, "index_loG.tif", indexLoG);
 #endif
-    
-        
+
+
     Free_Array(maximLoG);
-    
+
     Free_Array(logImage);
-    
-    
+
+
      // Determining the level with the highest frequency of pixels
-     
+
     Array * level = Make_Array_With_Shape(PLAIN_KIND, UINT32_TYPE, Coord2(img.GetGridY(), img.GetGridX()));
     uint32 * lev = AUINT32(level);
-     
+
     Use_Reflective_Boundary();
-     
-    Frame * f = Make_Frame(indexLoG, Coord2(imgPara.radius,imgPara.radius),Coord2(0, 0));      
+
+    Frame * f = Make_Frame(indexLoG, Coord2(imgPara.radius,imgPara.radius),Coord2(0, 0));
     Histogram * h = Make_Histogram(UVAL, img.GetDepth(), ValU(1), ValU(0));
-    Place_Frame(f, 0);  
-     
+    Place_Frame(f, 0);
+
     for (Dimn_Type y = 0; y <= img.GetHeight()-imgPara.radius; y += imgPara.radius){
      for (Dimn_Type x = 0; x <= img.GetWidth()-imgPara.radius; x += imgPara.radius){
-       
+
        Place_Frame(f, Coord2IdxA(indexLoG, Coord2(y, x)));
        Empty_Histogram(h);
        Histagain_Array(h, f, 0);
-     
+
        Size_Type * hValues = h->counts;
-     
+
        int32 maxVal = 0;
        int32 maxPlane = 0;
-     
+
        for (int i = 0; i < img.GetDepth(); i++) {
          if (hValues[i] > maxVal) {
            maxVal = hValues[i];
            maxPlane = (uint32) i;
          }
        }
-     
+
        Indx_Type p = Coord2IdxA(level, Coord2(y/imgPara.radius, x/imgPara.radius));
        lev[p] = maxPlane;
      }
     }
-     
-     
+
+
 #ifdef DEVELOP
   ShowArray(img, imgPara, "level_loG.tif", level);
 #endif
-     
+
   if (imgPara.verbose) {
      std::cout << "Optimal planes selected (using LoG)" << std::endl;
   }
-     
-     
+
+
   Free_Frame(f);
   Free_Histogram(h);
   Free_Array(indexLoG);
@@ -1728,67 +1731,67 @@ namespace ProjectionMethod {
   return level;
   }
 
-  
+
   /***********************
    * Select the z-plane with the most occurrences of bright pixel
    **********************/
-  
+
   Array * BrightPixelDistribution (RasterizedImage & img, ParaSet & imgPara, Array *maxim, Array *index){
-    
+
     int tmpGridX = ceil ((double)img.GetWidth()/(double)imgPara.radius);
     int tmpGridY  = ceil ((double)img.GetHeight()/(double)imgPara.radius);
-    
+
     Array  *level = Make_Array_With_Shape(PLAIN_KIND,FLOAT32_TYPE,Coord3(img.GetDepth(), img.GetHeight(), img.GetWidth()));
     Array_Op_Scalar(level, SET_OP, FLOAT32_TYPE, ValF(0));
     float32 *lev   = AFLOAT32(level);
-    
+
     Array  *level2 = Make_Array_With_Shape(PLAIN_KIND,FLOAT32_TYPE,Coord3(img.GetDepth(), tmpGridY,tmpGridX));
     Array_Op_Scalar(level2, SET_OP, FLOAT32_TYPE, ValF(0));
     float32 *lev2   = AFLOAT32(level2);
-    
+
     Array * finalLevel = Make_Array_With_Shape(PLAIN_KIND, UINT32_TYPE, Coord2(tmpGridY, tmpGridX));
     Array_Op_Scalar(finalLevel, SET_OP, UINT32_TYPE, ValU(0));
     uint32 * finVals = AUINT32(finalLevel);
-    
-    
-    
+
+
+
     uint32 *idx   = AUINT32(index);
     uint8  *max   = AUINT8(maxim);
     uint8 *imgVals = AUINT8(img.GetImage());
-    
+
     Use_Extend_Boundary();
-    
+
 //    Frame * fid = Make_Frame(index,Coord2(imgPara.radius,imgPara.radius),Coord2(0,0));
 //    Frame * fmx = Make_Frame(maxim,Coord2(imgPara.radius,imgPara.radius),Coord2(0,0));
-    
+
     Frame * fimg = Make_Frame(img.GetImage(),Coord3(img.GetDepth(), imgPara.radius,imgPara.radius),Coord3(0,0,0));
 
-    
+
 //    Offs_Type * off = Frame_Offsets(fid);
 //    Size_Type fsz   = AForm_Size(fid);
-    
+
     Histogram * wnh = Make_Histogram(UVAL,256,ValU(1),ValU(0));
-    
+
     Size_Type * hcnt = wnh->counts;
     Size_Type * dcnt = (Size_Type *) Guarded_Malloc(sizeof(Size_Type)*img.GetDepth(), Program_Name());
-    
+
     Indx_Type lp = 0;
-    
-    
+
+
     for (Dimn_Type y = 0; y <= img.GetHeight()-imgPara.radius; y += imgPara.radius){
       for (Dimn_Type x = 0; x <= img.GetWidth()-imgPara.radius; x += imgPara.radius){
         int thr;
-        
+
         Indx_Type p = y*img.GetWidth() + x;
-        
+
         Place_Frame(fimg,p);
-        
+
         Empty_Histogram(wnh);
         Histagain_Array(wnh,fimg,0);
-        
+
         int sum = 0;
         int finalThreshold = 0;
-        
+
           for (thr = 255; thr > 0; thr--)
             { sum += hcnt[thr];
               if (sum >= imgPara.threshold) {
@@ -1799,7 +1802,7 @@ namespace ProjectionMethod {
         for (int d = 0; d < img.GetDepth(); d++){
           dcnt[d] = 0;
         }
-        
+
         for (int z=0; z<img.GetDepth(); z++) {
           for (int r = 0; r<imgPara.radius; r++) {
             for (int s = 0; s<imgPara.radius; s++) {
@@ -1813,10 +1816,10 @@ namespace ProjectionMethod {
             }
           }
         }
-        
+
         int maxFequency = 0;
         int bestZ = 0;
-        
+
         for (int z=0; z<img.GetDepth(); z++) {
           Indx_Type pq = (z*tmpGridY + y/imgPara.radius ) * tmpGridX + (x/imgPara.radius);
 
@@ -1826,10 +1829,10 @@ namespace ProjectionMethod {
           }
         }
         finVals[(y/imgPara.radius ) * tmpGridX + (x/imgPara.radius)] = bestZ;
-        
+
 //        if (Frame_Within_Array(fimg)){
-//          
-//          
+//
+//
 //          uint8  *mx = max + p;
 //          uint32 *ix = idx + p;
 //
@@ -1841,13 +1844,13 @@ namespace ProjectionMethod {
 //          std::cout << "Frame should never be outside array" << std::endl;
 //          exit (0);
 //        }
-//        
+//
 //        { int best = 0;
 //          int plan;
-//          
+//
 //          for (int d = 0; d < img.GetDepth(); d++){
-//            
-//            
+//
+//
 //            if (dcnt[d] > best){
 //              best = dcnt[d];
 //              plan = d;
@@ -1855,87 +1858,87 @@ namespace ProjectionMethod {
 //          }
 //          lp = Coord2IdxA(level, Coord2(y/imgPara.radius, x/imgPara.radius));
 //          lev[lp] = plan;
-//          
+//
 //#ifdef DEVELOP
 //          Indx_Type pDist;
-//          
+//
 //          for (int j=0; j<img.GetDepth(); j++) {
 //            pDist = Coord2IdxA(dist, Coord3(x/imgPara.radius, y/imgPara.radius, j));
 //            dis[pDist] = (uint8)dcnt[j];
 //          }
 //#endif
 //        }
-        
+
       }
     }
     Write_Image("tets4.tif", level, DONT_PRESS);
     Write_Image("tets5.tif", finalLevel, DONT_PRESS);
 
-    
+
     free(dcnt);
     Kill_Histogram(wnh);
 //    Kill_Frame(fid);
     Kill_Frame(fimg);
 //    Kill_Frame(fmx);
-    
+
 #ifdef DEVELOP
     ShowArray(img, imgPara, "largest.tif",largest);
     Free_Array(largest);
-    
+
     Write_Image("dist.tif", dist, DONT_PRESS);
     Free_Array(dist);
 #endif
-    
+
     if (imgPara.verbose){
       std::cout << "Z-planes selected" << std::endl;
     }
-    
+
     return level2;
   }
-  
-  
+
+
   Array * SelectPlanes_Variance_UsingHeightMap(RasterizedImage & img, ParaSet & imgPara, ExtendedParaSet & imgPara2, Array * heightMap) {
-    
+
       Array  *level = Make_Array_With_Shape(PLAIN_KIND,UINT32_TYPE,Coord2(img.GetGridY(),img.GetGridX()));
       uint32 *lev   = AUINT32(level);
       uint32 * med  = AUINT32(heightMap);
-      
+
       Use_Reflective_Boundary();
-      
+
       Frame * f = Make_Frame(img.GetImage(),Coord3(1,imgPara.radius,imgPara.radius),Coord3(0, 0, 0));
       Histogram * h = Make_Histogram(UVAL,256,ValU(1),ValU(0));
-      
+
       Place_Frame(f, 0);
-      
+
       double maxVar;
       double maxmaxVar;
       int best, maxBest;
       Indx_Type p;
-      
+
       for (Dimn_Type y = 0; y <= img.GetHeight()-imgPara.radius; y += imgPara.radius){
         for (Dimn_Type x = 0; x <= img.GetWidth()-imgPara.radius; x += imgPara.radius){
           best = 0;
           maxVar = 1.5;
           maxmaxVar = 0;
           maxBest = 0;
-          
+
           //        std::cout << x << ", " << y << "   ( " << x/imgPara.radius << ", " << y/ imgPara.radius << std::endl;
           Indx_Type medIdx = (y/imgPara.radius) * img.GetGridX()+ (x/imgPara.radius);
-          
+
           for (Dimn_Type z=med[medIdx]+imgPara2.distance1 ; z<=med[medIdx]+imgPara2.distance2 ; z++) {
             if ((z < 0) or (z >= img.GetDepth())) {
               continue;
             }
-            
+
             p = Coord2IdxA(img.GetImage(), Coord3(z, y, x));
             Place_Frame(f, p);
-            
+
             Empty_Histogram(h);
             Histagain_Array(h,f,0);
             //          if (Histogram_Variance(h) > 0) {
             //             std::cout << "     " << z << " => " << Histogram_Variance(h) << std::endl;
             //          }
-            
+
             if (maxVar < Histogram_Variance(h)) {
               maxVar = Histogram_Variance(h);
               best = z;
@@ -1945,18 +1948,18 @@ namespace ProjectionMethod {
               maxBest = z;
             }
           }
-          
+
           double betweenVar = maxVar;
           int betweenBest = 0;
-          
+
           if (best == med[medIdx]-imgPara.distance) {
-            
+
             int z = best -1;
             while (z >= 0) {
-              
+
               p = Coord2IdxA(img.GetImage(), Coord3(z, y, x));
               Place_Frame(f, p);
-              
+
               Empty_Histogram(h);
               Histagain_Array(h,f,0);
               //            if (Histogram_Variance(h) > 1) {
@@ -1966,7 +1969,7 @@ namespace ProjectionMethod {
                 maxmaxVar = Histogram_Variance(h);
                 maxBest = z;
               }
-              
+
               if (betweenVar < Histogram_Variance(h)) {
                 betweenVar = Histogram_Variance(h);
                 betweenBest = z;
@@ -1975,15 +1978,15 @@ namespace ProjectionMethod {
                 z = -1;
               }
             }
-            
+
           } else if (best == 0) {
-            
+
             int z = med[medIdx]-imgPara.distance -1;
             while (z >= 0) {
-              
+
               p = Coord2IdxA(img.GetImage(), Coord3(z, y, x));
               Place_Frame(f, p);
-              
+
               Empty_Histogram(h);
               Histagain_Array(h,f,0);
               //            if (Histogram_Variance(h) > 0) {
@@ -1993,7 +1996,7 @@ namespace ProjectionMethod {
                 maxmaxVar = Histogram_Variance(h);
                 maxBest = z;
               }
-              
+
               if (betweenVar < Histogram_Variance(h)) {
                 betweenVar = Histogram_Variance(h);
                 betweenBest = z;
@@ -2004,18 +2007,18 @@ namespace ProjectionMethod {
                 z = -1;
               }
             }
-            
+
           }
-          
-          
+
+
           if (best == med[medIdx]+imgPara.distance) {
-            
+
             int z = best + 1;
             while (z < img.GetDepth()) {
-              
+
               p = Coord2IdxA(img.GetImage(), Coord3(z, y, x));
               Place_Frame(f, p);
-              
+
               Empty_Histogram(h);
               Histagain_Array(h,f,0);
               //            if (Histogram_Variance(h) > 0) {
@@ -2025,7 +2028,7 @@ namespace ProjectionMethod {
                 //              maxmaxVar = Histogram_Variance(h);
                 maxBest = z;
               }
-              
+
               if (maxVar < Histogram_Variance(h)) {
                 maxVar = Histogram_Variance(h);
                 best = z;
@@ -2034,15 +2037,15 @@ namespace ProjectionMethod {
                 z = img.GetDepth();
               }
             }
-            
+
           } else if (best == 0) {
-            
+
             int z = med[medIdx]+imgPara.distance + 1;
             while (z < img.GetDepth()) {
-              
+
               p = Coord2IdxA(img.GetImage(), Coord3(z, y, x));
               Place_Frame(f, p);
-              
+
               Empty_Histogram(h);
               Histagain_Array(h,f,0);
               //            if (Histogram_Variance(h) > 1) {
@@ -2052,7 +2055,7 @@ namespace ProjectionMethod {
                 maxmaxVar = Histogram_Variance(h);
                 maxBest = z;
               }
-              
+
               if (maxVar < Histogram_Variance(h)) {
                 maxVar = Histogram_Variance(h);
                 best = z;
@@ -2063,13 +2066,14 @@ namespace ProjectionMethod {
                 z = img.GetDepth();
               }
             }
-            
+
           }
-          
-          if (abs(betweenBest - med[medIdx]-imgPara.distance) < abs(best-med[medIdx]+imgPara.distance)) {
+
+
+          if (std::abs(betweenBest - int(med[medIdx])-imgPara.distance) < std::abs(best-int(med[medIdx])+imgPara.distance)) {
             best = betweenBest;
           }
-          
+
           if (best == 0) {
             best = maxBest;
           }
@@ -2078,8 +2082,8 @@ namespace ProjectionMethod {
           lev[p] = best;
         }
       }
-      
-      
+
+
 #ifdef DEVELOP
       ShowArray(img, imgPara, "level_Variance.tif", level);
 #endif
@@ -2088,11 +2092,9 @@ namespace ProjectionMethod {
       }
       Free_Frame(f);
       Free_Histogram(h);
-      
+
       return level;
 
   }
 
 }
-
-


### PR DESCRIPTION
…gned types

Hi Corinna,
gcc6 and above are throwing errors when compiling premosa. MOstly due to the fact that the C style abs function that you use partly in your code, are undefined for unsigned types (by the nature of it). I try to fix this with this PR. I am not sure, if this breaks anything though.
Best,
P 